### PR TITLE
Fix dynamic review detail access

### DIFF
--- a/Magezon/PageBuilder/Block/Element/RecentReviews.php
+++ b/Magezon/PageBuilder/Block/Element/RecentReviews.php
@@ -182,7 +182,7 @@ class RecentReviews extends \Magezon\Builder\Block\AbstractProduct
     public function getReviewContent(\Magento\Review\Model\Review $review): string
     {
         $element = $this->getElement();
-        $detail = $review->getDetail(); // método dinámico (funciona porque está en review_detail)
+        $detail = $review->getData('detail');
         $content = $detail;
         $reviewContentLength = $element->getData('review_content_length');
         if ($reviewContentLength) {

--- a/Magezon/PageBuilder/view/frontend/templates/element/recent_reviews.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/recent_reviews.phtml
@@ -93,7 +93,7 @@ $reviewContent       = $element->getData('review_content');
 					<?php if ($reviewContent) { ?>
 	                <div class="mgz-review-content">
 	                	<?php
-						$detail  = $_review->getDetail();
+                                                $detail  = $_review->getData('detail');
 						$content = $this->getReviewContent($_review);
 	                	?>
 	                	<div class="<?= ($detail !== $content) ? 'mgz-review-content-short' : '' ?>"><?= $content ?> 


### PR DESCRIPTION
## Summary
- avoid dynamic getDetail call by using `getData('detail')`
- update template to fetch review details via explicit data access

## Testing
- `php -l Magezon/PageBuilder/Block/Element/RecentReviews.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5380be08320864264dab897d12b