### PR TITLE
Fix request retrieval in builder controller

### DIFF
--- a/Magezon/PageBuilder/Controller/Adminhtml/Builder/Load.php
+++ b/Magezon/PageBuilder/Controller/Adminhtml/Builder/Load.php
@@ -66,7 +66,7 @@ class Load extends Action
     public function execute()
     {
         $block = $this->layoutFactory->create()->createBlock(\Magezon\PageBuilder\Block\Builder::class);
-        $block->addData($this->request->getPostValue());
+        $block->addData($this->getRequest()->getPostValue());
         $resultRaw = $this->resultRawFactory->create();
         return $resultRaw->setContents($block->toHtml());
     }


### PR DESCRIPTION
## Summary
- update builder load controller to use `getRequest()` when fetching POST data

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840a53a53988320a8f5bce4811b8d0e