### PR TITLE
Fix annotation reference in TemplateList

### DIFF
--- a/Magezon/PageBuilder/Model/Source/TemplateList.php
+++ b/Magezon/PageBuilder/Model/Source/TemplateList.php
@@ -22,7 +22,7 @@ class TemplateList implements \Magezon\Builder\Model\Source\ListInterface
     protected $templateFactory;
 
     /**
-     * @var \Magento\PageBuilder\Model\ResourceModel\Template\CollectionFactory
+     * @var \Magezon\PageBuilder\Model\ResourceModel\Template\CollectionFactory
      */
     protected $collectionFactory;
 


### PR DESCRIPTION
## Summary
- replace Magento collection annotation with module collection class

## Testing
- `php -l Magezon/PageBuilder/Model/Source/TemplateList.php`

------
https://chatgpt.com/codex/tasks/task_e_6840a53dc5c88320969e1545495e9b96