### PR TITLE
Refactor accordion template

### DIFF
--- a/Magezon/PageBuilder/ViewModel/AccordionData.php
+++ b/Magezon/PageBuilder/ViewModel/AccordionData.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+
+class AccordionData implements ArgumentInterface
+{
+    public function __construct(private CoreHelper $coreHelper) {}
+
+    public function filter(string $text): string
+    {
+        return $this->coreHelper->filter($text);
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_accordion.xml
+++ b/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_accordion.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="magezon.pagebuilder.accordion">
+            <arguments>
+                <argument name="view_model" xsi:type="object">Magezon\PageBuilder\ViewModel\AccordionData</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/Magezon/PageBuilder/view/frontend/templates/element/accordion.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/accordion.phtml
@@ -1,12 +1,16 @@
 <?php
-$coreHelper       = $this->helper('\Magezon\Core\Helper\Data');
-$elements         = $this->getELements();
-$count            = count($elements);
-$element          = $this->getElement();
-$title            = $coreHelper->filter($element->getData('title'));
-$titleAlign       = $element->getData('title_align');
-$titleTag         = $element->getData('title_tag') ? $element->getData('title_tag') : 'h2';
-$description      = $coreHelper->filter($element->getData('description'));
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magezon\PageBuilder\ViewModel\AccordionData $viewModel
+ */
+$viewModel       = $block->getViewModel();
+$elements        = $block->getELements();
+$count           = count($elements);
+$element         = $block->getElement();
+$title           = $viewModel->filter($element->getData('title'));
+$titleAlign      = $element->getData('title_align');
+$titleTag        = $element->getData('title_tag') ? $element->getData('title_tag') : 'h2';
+$description     = $viewModel->filter($element->getData('description'));
 $showLine         = $element->getData('show_line');
 $hideEmptySection = $element->getData('hide_empty_section');
 $collapsibleAll   = $element->getData('collapsible_all') ? 'true' : 'false';

--- a/Magezon/PageBuilder/view/frontend/web/js/collapse.js
+++ b/Magezon/PageBuilder/view/frontend/web/js/collapse.js
@@ -31,7 +31,7 @@ define([
             }
 
             $panelList.each(function(index, el) {
-                $(this).children('.mgz-panel-heading').find('a').click(function(event) {
+                $(this).children('.mgz-panel-heading').find('a').on('click', function(event) {
                     if (self.options.atLeastOneOpen) {
                         if ($(this).parents('.mgz-panel.mgz-active').length) return false;
                     }


### PR DESCRIPTION
## Summary
- use AccordionData view model
- add layout for Accordion view model
- migrate helper calls to view model and $block usage in accordion template
- prefer `.on('click')` in collapse JS

## Testing
- `php -l Magezon/PageBuilder/ViewModel/AccordionData.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a55032e88320a41a96aa03659362