### PR TITLE
Refactor call_to_action template

### DIFF
--- a/Magezon/PageBuilder/ViewModel/CallToActionViewModel.php
+++ b/Magezon/PageBuilder/ViewModel/CallToActionViewModel.php
@@ -1,0 +1,42 @@
+<?php
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+use Magezon\Builder\Helper\Data as BuilderHelper;
+use Magezon\PageBuilder\Block\Element\CallToAction;
+
+class CallToActionViewModel implements ArgumentInterface
+{
+    public function __construct(
+        private CoreHelper $coreHelper,
+        private BuilderHelper $builderHelper,
+        private CallToAction $block
+    ) {
+    }
+
+    public function getElement()
+    {
+        return $this->block->getElement();
+    }
+
+    public function getFilteredText(?string $text): string
+    {
+        return $this->coreHelper->filter(trim((string) $text));
+    }
+
+    public function getImageUrl(?string $path): string
+    {
+        return $this->builderHelper->getImageUrl($path);
+    }
+
+    public function getLinkParams($data): array
+    {
+        return $this->block->getLinkParams($data);
+    }
+
+    public function getBlock(): CallToAction
+    {
+        return $this->block;
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_call_to_action.xml
+++ b/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_call_to_action.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="magezon.pagebuilder.call_to_action">
+            <arguments>
+                <argument name="view_model" xsi:type="object">Magezon\PageBuilder\ViewModel\CallToActionViewModel</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/Magezon/PageBuilder/view/frontend/templates/element/call_to_action.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/call_to_action.phtml
@@ -1,17 +1,18 @@
 <?php
-$coreHelper            = $this->helper('\Magezon\Core\Helper\Data');
-$builderHelper         = $this->helper('\Magezon\Builder\Helper\Data');
-$element               = $this->getElement();
+/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Magezon\PageBuilder\ViewModel\CallToActionViewModel $viewModel */
+
+$element               = $block->getElement();
 $contentPosition       = $element->getData('content_position');
 $imagePosition         = $element->getData('image_position');
-$boxLink               = $this->getLinkParams($element->getData('box_link'));
-$title                 = $coreHelper->filter(trim($element->getData('title')));
+$boxLink               = $viewModel->getLinkParams($element->getData('box_link'));
+$title                 = $viewModel->getFilteredText($element->getData('title'));
 $titleType             = $element->getData('title_type');
-$image                 = $builderHelper->getImageUrl($element->getData('image'));
-$description           = $coreHelper->filter(trim($element->getData('description')));
+$image                 = $viewModel->getImageUrl($element->getData('image'));
+$description           = $viewModel->getFilteredText($element->getData('description'));
 $enableButton          = $element->getData('enable_button');
 $buttonTitle           = trim($element->getData('button_title'));
-$buttonLink            = $this->getLinkParams($element->getData('button_link'));
+$buttonLink            = $viewModel->getLinkParams($element->getData('button_link'));
 $btnStyle              = $element->getData('button_style');
 $btnSize               = $element->getData('button_size');
 $icon                  = $element->getData('icon');
@@ -30,42 +31,42 @@ if ($image && $imageHoverAnimation) $classes[] = 'mgz-bg-transform-' . $imageHov
 if ($label) $classes[] = 'has-label';
 ?>
 <div class="mgz-cta mgz-animated-content <?= implode(' ', $classes) ?>">
-	<?php if ($boxLink['url']) { ?>
-		<a class="mgz-absolute-link" href="<?= $boxLink['url'] ?>" title="<?= $block->escapeHtml($boxLink['title']) ?>" <?= $boxLink['blank'] ? 'target="_blank"' : '' ?> <?= $boxLink['nofollow'] ? 'rel="nofollow"' : '' ?>></a>
-	<?php } ?>
-		<?php if ($image) { ?>
-		<div class="mgz-cta-bg-wrapper mgz-bg-transform-wrapper">
-			<div class="mgz-cta-bg mgz-bg" style="background-image: url(<?= $image ?>);"></div>
-			<div class="mgz-cta-bg-overlay"></div>
-		</div>
-		<?php } ?>
-		<div class="mgz-cta-content mgz-flex-position-<?= $contentPosition ?>">
-			<?php if ($icon || $title || $description || ($enableButton && $buttonTitle)) { ?>
-			<div class="mgz-cta-content-inner">
-				<?php if ($icon) { ?>
-					<div class="mgz-cta-content-item <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>">
-						<div class="mgz-icon-wrapper mgz-icon-size-<?= $iconSize ?> mgz-animated-item--<?= $contentHoverAnimation ?>">
-							<i class="mgz-icon-element <?= $icon ?>"></i>
-						</div>
-					</div>
-				<?php } ?>
-				<?php if ($title) { ?>
-					<<?= $titleType ?> class="mgz-cta-content-item mgz-cta-title <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>"><?= $title ?></<?= $titleType ?>>
-				<?php } ?>
-				<?php if ($description) { ?>
-					<div class="mgz-cta-content-item mgz-cta-description <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>"><?= $description ?></div>
-				<?php } ?>
-				<?php if ($enableButton && $buttonTitle) { ?>
-				<div class="mgz-cta-content-item mgz-cta-button-wrapper mgz-btn-style-<?= $btnStyle ?> mgz-btn-size-<?= $btnSize ?> <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>">
-					<a href="<?= $buttonLink['url'] ?>" class="mgz-btn mgz-link" title="<?= $block->escapeHtml($buttonLink['title']) ?>" <?= $buttonLink['blank'] ? 'target="_blank"' : '' ?> <?= $buttonLink['nofollow'] ? 'rel="nofollow"' : '' ?>><?= $buttonTitle ?></a>
-				</div>
-				<?php } ?>
-			</div>
-			<?php } ?>
-		</div>
-		<?php if ($label) { ?>
-			<div class="mgz-cta-label">
-				<div class="mgz-cta-label-inner"><?= $label ?></div>
-			</div>
-		<?php } ?>
+    <?php if ($boxLink['url']) { ?>
+        <a class="mgz-absolute-link" href="<?= $block->escapeUrl($boxLink['url']) ?>" title="<?= $block->escapeHtml($boxLink['title']) ?>" <?= $boxLink['blank'] ? 'target="_blank"' : '' ?> <?= $boxLink['nofollow'] ? 'rel="nofollow"' : '' ?>></a>
+    <?php } ?>
+    <?php if ($image) { ?>
+        <div class="mgz-cta-bg-wrapper mgz-bg-transform-wrapper">
+            <div class="mgz-cta-bg mgz-bg" style="background-image: url(<?= $block->escapeUrl($image) ?>);"></div>
+            <div class="mgz-cta-bg-overlay"></div>
+        </div>
+    <?php } ?>
+    <div class="mgz-cta-content mgz-flex-position-<?= $contentPosition ?>">
+        <?php if ($icon || $title || $description || ($enableButton && $buttonTitle)) { ?>
+            <div class="mgz-cta-content-inner">
+                <?php if ($icon) { ?>
+                    <div class="mgz-cta-content-item <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>">
+                        <div class="mgz-icon-wrapper mgz-icon-size-<?= $iconSize ?> mgz-animated-item--<?= $contentHoverAnimation ?>">
+                            <i class="mgz-icon-element <?= $icon ?>"></i>
+                        </div>
+                    </div>
+                <?php } ?>
+                <?php if ($title) { ?>
+                    <<?= $titleType ?> class="mgz-cta-content-item mgz-cta-title <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>"><?= $title ?></<?= $titleType ?>>
+                <?php } ?>
+                <?php if ($description) { ?>
+                    <div class="mgz-cta-content-item mgz-cta-description <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>"><?= $description ?></div>
+                <?php } ?>
+                <?php if ($enableButton && $buttonTitle) { ?>
+                <div class="mgz-cta-content-item mgz-cta-button-wrapper mgz-btn-style-<?= $btnStyle ?> mgz-btn-size-<?= $btnSize ?> <?= $contentHoverAnimation ? 'mgz-animated-item--' . $contentHoverAnimation : '' ?>">
+                    <a href="<?= $block->escapeUrl($buttonLink['url']) ?>" class="mgz-btn mgz-link" title="<?= $block->escapeHtml($buttonLink['title']) ?>" <?= $buttonLink['blank'] ? 'target="_blank"' : '' ?> <?= $buttonLink['nofollow'] ? 'rel="nofollow"' : '' ?>><?= $buttonTitle ?></a>
+                </div>
+                <?php } ?>
+            </div>
+        <?php } ?>
+    </div>
+    <?php if ($label) { ?>
+        <div class="mgz-cta-label">
+            <div class="mgz-cta-label-inner"><?= $label ?></div>
+        </div>
+    <?php } ?>
 </div>


### PR DESCRIPTION
## Summary
- add `CallToActionViewModel` for CTA logic
- wire ViewModel using new `magezon_pagebuilder_call_to_action.xml`
- update `call_to_action.phtml` to remove `$this` and use `$block`/`ViewModel`

## Testing
- `php -l Magezon/PageBuilder/ViewModel/CallToActionViewModel.php`
- `php -l Magezon/PageBuilder/view/frontend/templates/element/call_to_action.phtml`


------
https://chatgpt.com/codex/tasks/task_e_6840a553cbb88320bd4dcc682f047472