### PR TITLE
Use ViewModel in content slider

### DIFF
--- a/Magezon/PageBuilder/Block/Element/ContentSlider.php
+++ b/Magezon/PageBuilder/Block/Element/ContentSlider.php
@@ -14,8 +14,26 @@
 
 namespace Magezon\PageBuilder\Block\Element;
 
+use Magento\Framework\View\Element\Template\Context;
+use Magezon\PageBuilder\ViewModel\ContentSlider as ViewModel;
+
 class ContentSlider extends \Magezon\Builder\Block\Element
 {
+    private ViewModel $viewModel;
+
+    public function __construct(
+        Context $context,
+        ViewModel $viewModel,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->viewModel = $viewModel;
+    }
+
+    public function getViewModel(): ViewModel
+    {
+        return $this->viewModel;
+    }
     /**
      * @return string
      */

--- a/Magezon/PageBuilder/ViewModel/ContentSlider.php
+++ b/Magezon/PageBuilder/ViewModel/ContentSlider.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+use Magezon\PageBuilder\Block\Element\ContentSlider as Block;
+
+class ContentSlider implements ArgumentInterface
+{
+    public function __construct(
+        private CoreHelper $coreHelper,
+        private Block $block
+    ) {}
+
+    public function getElement()
+    {
+        return $this->block->getElement();
+    }
+
+    public function filter(?string $text): string
+    {
+        return $this->coreHelper->filter($text ?? '');
+    }
+
+    public function getSerializedOptions(array $options): string
+    {
+        return $this->coreHelper->serialize($options);
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_content_slider.xml
+++ b/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_content_slider.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="magezon.pagebuilder.content_slider">
+            <arguments>
+                <argument name="view_model" xsi:type="object">Magezon\PageBuilder\ViewModel\ContentSlider</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/Magezon/PageBuilder/view/frontend/templates/element/content_slider.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/content_slider.phtml
@@ -1,39 +1,44 @@
 <?php
-$coreHelper      = $this->helper('\Magezon\Core\Helper\Data');
-$element         = $this->getElement();
-$title           = $coreHelper->filter($element->getData('title'));
+/**
+ * @var \Magezon\PageBuilder\Block\Element\ContentSlider $block
+ * @var \Magezon\PageBuilder\ViewModel\ContentSlider $viewModel
+ */
+$viewModel = $block->getViewModel();
+
+$element         = $viewModel->getElement();
+$title           = $viewModel->filter($element->getData('title'));
 $titleAlign      = $element->getData('title_align');
 $titleTag        = $element->getData('title_tag') ? $element->getData('title_tag') : 'h2';
-$description     = $coreHelper->filter($element->getData('description'));
+$description     = $viewModel->filter($element->getData('description'));
 $showLine        = $element->getData('show_line');
 $linePosition    = $element->getData('line_position');
-$items           = $this->toObjectArray($element->getItems());
+$items           = $block->toObjectArray($element->getItems());
 $htmlId          = $element->getHtmlId();
-$carouselOptions = $this->getOwlCarouselOptions();
-$classes         = $this->getOwlCarouselClasses();
+$carouselOptions = $block->getOwlCarouselOptions();
+$classes         = $block->getOwlCarouselClasses();
 ?>
 <?php if (count($items)) { ?>
 <div class="mgz-block">
-	<?php if ($title || $description) { ?>
-	<div class="mgz-block-heading mgz-block-heading-align-<?= $titleAlign ?><?= $showLine ? ' mgz-block-heading-line' : '' ?> mgz-block-heading-line-position-<?= $linePosition ?>">
-		<?php if ($title) { ?>
-			<<?= $titleTag ?> class="title"><?= $title ?></<?= $titleTag ?>>
-		<?php } ?>
-		<?php if ($description) { ?>
-			<div class="info"><?= $description ?></div>
-		<?php } ?>
-	</div>
-	<?php } ?>
-	<div class="mgz-block-content">
-		<?php if ($items && count($items)) { ?>
-			<div class="mgz-carousel owl-carousel <?= implode(' ', $classes) ?>" data-mage-init='{"Magezon_Builder/js/carousel":<?= $coreHelper->serialize($carouselOptions) ?>}'>
-				<?php foreach ($items as $item) { ?>
-					<div class="mgz-content-carouse-slide">
-						<?= $coreHelper->filter($item['content']) ?>						
-					</div>
-				<?php } ?>
-			</div>
-		<?php } ?>
-	</div>
+        <?php if ($title || $description) { ?>
+        <div class="mgz-block-heading mgz-block-heading-align-<?= $titleAlign ?><?= $showLine ? ' mgz-block-heading-line' : '' ?> mgz-block-heading-line-position-<?= $linePosition ?>">
+                <?php if ($title) { ?>
+                        <<?= $titleTag ?> class="title"><?= $title ?></<?= $titleTag ?>>
+                <?php } ?>
+                <?php if ($description) { ?>
+                        <div class="info"><?= $description ?></div>
+                <?php } ?>
+        </div>
+        <?php } ?>
+        <div class="mgz-block-content">
+                <?php if ($items && count($items)) { ?>
+                        <div class="mgz-carousel owl-carousel <?= implode(' ', $classes) ?>" data-mage-init='{"Magezon_Builder/js/carousel":<?= $viewModel->getSerializedOptions($carouselOptions) ?>}'>
+                                <?php foreach ($items as $item) { ?>
+                                        <div class="mgz-content-carouse-slide">
+                                                <?= $viewModel->filter($item['content']) ?>
+                                        </div>
+                                <?php } ?>
+                        </div>
+                <?php } ?>
+        </div>
 </div>
 <?php } ?>


### PR DESCRIPTION
## Summary
- refactor `content_slider.phtml` to rely on `$block` and a ViewModel
- inject new ViewModel into `ContentSlider` block via layout
- add `ContentSlider` ViewModel

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5557acc83209645fcb2f4d1cc3a