### PR TITLE
Use block variable in facebook comments template

### DIFF
--- a/Magezon/PageBuilder/view/frontend/templates/element/facebook_comments.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/facebook_comments.phtml
@@ -1,5 +1,5 @@
 <?php
-$element  = $this->getElement();
+$element  = $block->getElement();
 $numPosts = (int)$element->getData('num_posts') ? (int)$element->getData('num_posts') : 5;
 $boxWidth = $element->getData('box_width');
 $pageUrl  = $element->getData('page_url');


### PR DESCRIPTION
## Summary
- use `$block` instead of `$this` in `facebook_comments.phtml`

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/facebook_comments.phtml` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a556abc083209cdaaff026eacf73