### PR TITLE
Fix facebook like template to use block

### DIFF
--- a/Magezon/PageBuilder/view/frontend/templates/element/facebook_like.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/facebook_like.phtml
@@ -1,5 +1,5 @@
 <?php
-$element = $this->getElement();
+$element = $block->getElement();
 $attrs   = [];
 if ($element->getData('btn_url')) $attrs['data-href'] = $element->getData('btn_url');
 if ($element->getData('btn_layout')) $attrs['data-layout'] = $element->getData('btn_layout');


### PR DESCRIPTION
## Summary
- update facebook like template to use `$block->getElement()` instead of `$this->getElement()`

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/facebook_like.phtml` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a559007c8320a88da660084b43b2