### PR TITLE
Add Facebook Page ViewModel

### DIFF
--- a/Magezon/PageBuilder/ViewModel/FacebookPage.php
+++ b/Magezon/PageBuilder/ViewModel/FacebookPage.php
@@ -1,0 +1,23 @@
+<?php
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Builder\Helper\Data as BuilderHelper;
+
+class FacebookPage implements ArgumentInterface
+{
+    /**
+     * @var BuilderHelper
+     */
+    protected $builderHelper;
+
+    public function __construct(BuilderHelper $builderHelper)
+    {
+        $this->builderHelper = $builderHelper;
+    }
+
+    public function getStyleProperty($value)
+    {
+        return $this->builderHelper->getStyleProperty($value);
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_facebook_page.xml
+++ b/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_facebook_page.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="magezon.pagebuilder.facebook_page">
+            <arguments>
+                <argument name="view_model" xsi:type="object">Magezon\PageBuilder\ViewModel\FacebookPage</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/Magezon/PageBuilder/view/frontend/templates/element/facebook_page.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/facebook_page.phtml
@@ -1,10 +1,14 @@
 <?php
-$builderHelper = $this->helper('\Magezon\Builder\Helper\Data');
-$element       = $this->getElement();
+$viewModel = $block->getViewModel();
+$element   = $block->getElement();
 $attrs['data-href']                  = $element->getData('page_url');
 $attrs['data-tabs']                  = $element->getData('page_tabs') ? $element->getData('page_tabs') : 'timeline';
-if ($element->getData('page_width')) $attrs['data-width'] = $builderHelper->getStyleProperty($element->getData('page_width'));
-if ($element->getData('page_height')) $attrs['data-height'] = $builderHelper->getStyleProperty($element->getData('page_height'));
+if ($element->getData('page_width')) {
+    $attrs['data-width'] = $viewModel->getStyleProperty($element->getData('page_width'));
+}
+if ($element->getData('page_height')) {
+    $attrs['data-height'] = $viewModel->getStyleProperty($element->getData('page_height'));
+}
 $attrs['data-small-header']          = $element->getData('small_header') ? 'true' : 'false';
 $attrs['data-adapt-container-width'] = $element->getData('adapt_container_width') ? 'true' : 'false';
 $attrs['data-hide-cover']            = $element->getData('hide_cover') ? 'true' : 'false';


### PR DESCRIPTION
## Summary
- add `FacebookPage` view model
- register the view model via layout
- update template to use `$block` and view model

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/facebook_page.phtml` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a55ad8748320872c5959417e25a0