### PR TITLE
Refactor flip_box template to use ViewModel

### DIFF
--- a/Magezon/PageBuilder/ViewModel/FlipBoxData.php
+++ b/Magezon/PageBuilder/ViewModel/FlipBoxData.php
@@ -1,0 +1,44 @@
+<?php
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+use Magezon\Builder\Helper\Data as BuilderHelper;
+use Magezon\PageBuilder\Block\Element\FlipBox as Block;
+
+class FlipBoxData implements ArgumentInterface
+{
+    private CoreHelper $coreHelper;
+    private BuilderHelper $builderHelper;
+    private Block $block;
+
+    public function __construct(
+        CoreHelper $coreHelper,
+        BuilderHelper $builderHelper,
+        Block $block
+    ) {
+        $this->coreHelper = $coreHelper;
+        $this->builderHelper = $builderHelper;
+        $this->block = $block;
+    }
+
+    public function getElement()
+    {
+        return $this->block->getElement();
+    }
+
+    public function filter(?string $text): string
+    {
+        return $this->coreHelper->filter($text ?? '');
+    }
+
+    public function getImageUrl(?string $image): string
+    {
+        return $image ? $this->builderHelper->getImageUrl($image) : '';
+    }
+
+    public function getBlock(): Block
+    {
+        return $this->block;
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_flip_box.xml
+++ b/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_flip_box.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="magezon.pagebuilder.flip_box">
+            <arguments>
+                <argument name="view_model" xsi:type="object">Magezon\PageBuilder\ViewModel\FlipBoxData</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/Magezon/PageBuilder/view/frontend/templates/element/flip_box.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/flip_box.phtml
@@ -1,17 +1,19 @@
 <?php
-$coreHelper    = $this->helper('\Magezon\Core\Helper\Data');
-$builderHelper = $this->helper('\Magezon\Builder\Helper\Data');
-$element       = $this->getElement();
-$primaryTitle  = $coreHelper->filter($element->getData('primary_title'));
-$primaryText   = $coreHelper->filter($element->getData('primary_text'));
-$primaryImage  = $element->getData('primary_image') ? $builderHelper->getImageUrl($element->getData('primary_image')) : '';
-$hoverTitle    = $coreHelper->filter($element->getData('hover_title'));
-$hoverText     = $coreHelper->filter($element->getData('hover_text'));
-$hoverImage    = $element->getData('hover_image') ? $builderHelper->getImageUrl($element->getData('hover_image')) : '';
+/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Magezon\PageBuilder\ViewModel\FlipBoxData $viewModel */
+$viewModel = $block->getViewModel();
+
+$element       = $block->getElement();
+$primaryTitle  = $viewModel->filter($element->getData('primary_title'));
+$primaryText   = $viewModel->filter($element->getData('primary_text'));
+$primaryImage  = $viewModel->getImageUrl($element->getData('primary_image'));
+$hoverTitle    = $viewModel->filter($element->getData('hover_title'));
+$hoverText     = $viewModel->filter($element->getData('hover_text'));
+$hoverImage    = $viewModel->getImageUrl($element->getData('hover_image'));
 $flipDirection = $element->getData('flip_direction');
 $enableButton  = $element->getData('enable_button');
 $buttonTitle   = $element->getData('button_title');
-$buttonLink    = $this->getLinkParams($element->getData('button_link'));
+$buttonLink    = $block->getLinkParams($element->getData('button_link'));
 $boxMinHeight  = $element->getData('box_min_height');
 $icon          = $element->getData('icon');
 $flipEffect    = $element->getData('flip_effect');


### PR DESCRIPTION
## Summary
- add `FlipBoxData` ViewModel
- register ViewModel in layout file
- refactor `flip_box.phtml` to remove helper usage and rely on `$block` and the ViewModel

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a55d51648320afc28ac19f3c61cc