### PR TITLE
Fix instagram template block reference

### DIFF
--- a/Magezon/PageBuilder/view/frontend/templates/element/instagram.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/instagram.phtml
@@ -14,7 +14,7 @@
 
 /** @var $block \Magezon\PageBuilder\Block\Element\Instagram */
 
-$element = $this->getElement();
+$element = $block->getElement();
 $options = [
     'onclick'       => $element->getOnclick(),
     'html_id'       => $element->getHtmlId(),


### PR DESCRIPTION
## Summary
- use `$block` instead of `$this` in the instagram element template

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/instagram.phtml` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a56592c48320acd5e307b5e187a7