### PR TITLE
Add ViewModel for message box element

### DIFF
--- a/Magezon/PageBuilder/ViewModel/MessageBoxData.php
+++ b/Magezon/PageBuilder/ViewModel/MessageBoxData.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+
+class MessageBoxData implements ArgumentInterface
+{
+    public function __construct(private CoreHelper $coreHelper) {}
+
+    public function getFilteredContent(string $content): string
+    {
+        return $this->coreHelper->filter($content);
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_messagebox.xml
+++ b/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_messagebox.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="magezon.pagebuilder.messagebox">
+            <arguments>
+                <argument name="view_model" xsi:type="object">Magezon\PageBuilder\ViewModel\MessageBoxData</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/Magezon/PageBuilder/view/frontend/templates/element/message_box.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/message_box.phtml
@@ -1,11 +1,16 @@
 <?php
-$element    = $this->getElement();
-$coreHelper = $this->helper('\Magezon\Core\Helper\Data');
-$boxStyle   = $element->getData('message_box_style');
-$boxShape   = $element->getData('message_box_shape');
-$icon       = $element->getData('icon');
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magezon\PageBuilder\ViewModel\MessageBoxData $viewModel
+ */
+$viewModel = $block->getViewModel();
+
+$element  = $block->getElement();
+$boxStyle = $element->getData('message_box_style');
+$boxShape = $element->getData('message_box_shape');
+$icon     = $element->getData('icon');
 ?>
-<div class="mgz-message-box mgz-message-box-<?= $boxStyle ?> mgz-message-box-<?= $boxShape ?>">
-	<div class="mgz-message-box-icon"><i class="<?= $icon ?>"></i></div>
-	<div class="mgz-message-box-content"><?= $coreHelper->filter($element->getContent()) ?></div>
+<div class="mgz-message-box mgz-message-box-<?= $block->escapeHtmlAttr($boxStyle) ?> mgz-message-box-<?= $block->escapeHtmlAttr($boxShape) ?>">
+    <div class="mgz-message-box-icon"><i class="<?= $block->escapeHtmlAttr($icon) ?>"></i></div>
+    <div class="mgz-message-box-content"><?= $viewModel->getFilteredContent($element->getContent()) ?></div>
 </div>


### PR DESCRIPTION
## Summary
- implement `MessageBoxData` ViewModel
- wire ViewModel via `magezon_pagebuilder_messagebox.xml`
- refactor `message_box.phtml` to use ViewModel and `$block`

## Testing
- `composer -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5673ac48320aa3d81059f473c5b