### PR TITLE
Fix template variable reference

### DIFF
--- a/Magezon/PageBuilder/view/frontend/templates/element/number_counter.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/number_counter.phtml
@@ -1,5 +1,5 @@
 <?php
-$element               = $this->getElement();
+$element               = $block->getElement();
 $beforeNumberText      = $element->getData('before_number_text');
 $afterNumberText       = $element->getData('after_number_text');
 $layout                = $element->getData('layout');


### PR DESCRIPTION
## Summary
- access element via `$block` rather than `$this`

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/number_counter.phtml` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a569d6908320929b49ad0f4af36b