### PR TITLE
Fix pinterest template script tag

### DIFF
--- a/Magezon/PageBuilder/view/frontend/templates/element/pinterest.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/pinterest.phtml
@@ -1,5 +1,5 @@
 <?php
-$element        = $this->getElement();
+$element        = $block->getElement();
 $showPinCcounts = $element->getData('show_pin_counts') ? $element->getData('show_pin_counts') : 'above';
 $buttonLarge    = $element->getData('button_large');
 $buttonRound    = $element->getData('button_round');
@@ -19,9 +19,8 @@ $buttonRound    = $element->getData('button_round');
 		});
 	</script>
 	<!-- PINTEREST -->
-	<script
-	    type="text/javascript"
-	    async defer
-	    src="//assets.pinterest.com/js/pinit.js"
-	></script>
+        <script
+            async defer
+            src="//assets.pinterest.com/js/pinit.js"
+        ></script>
 </span>


### PR DESCRIPTION
## Summary
- clean up pinterest.phtml

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/pinterest.phtml` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a56cb18c8320b36ff540812e8f67