### PR TITLE
Refactor product_grid to use ViewModel

### DIFF
--- a/Magezon/PageBuilder/Block/Element/ProductGrid.php
+++ b/Magezon/PageBuilder/Block/Element/ProductGrid.php
@@ -19,6 +19,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\View\DesignInterface;
 use Magezon\Core\Model\ProductList;
 use Magezon\Core\Helper\Data as CoreHelper;
+use Magezon\PageBuilder\ViewModel\ProductGrid as ViewModel;
 
 /**
  * Product grid block for page builder.
@@ -56,6 +57,11 @@ class ProductGrid extends \Magezon\Builder\Block\ListProduct
     private $design;
 
     /**
+     * @var ViewModel
+     */
+    private $viewModel;
+
+    /**
      * Constructor.
      *
      * @param HttpContext $httpContext
@@ -73,6 +79,7 @@ class ProductGrid extends \Magezon\Builder\Block\ListProduct
         DesignInterface $design,
         ProductList $productList,
         CoreHelper $coreHelper,
+        ViewModel $viewModel,
         array $data = []
     ) {
         parent::__construct($data);
@@ -82,6 +89,12 @@ class ProductGrid extends \Magezon\Builder\Block\ListProduct
         $this->design = $design;
         $this->productList = $productList;
         $this->coreHelper = $coreHelper;
+        $this->viewModel = $viewModel;
+    }
+
+    public function getViewModel(): ViewModel
+    {
+        return $this->viewModel;
     }
 
     /**

--- a/Magezon/PageBuilder/ViewModel/ProductGrid.php
+++ b/Magezon/PageBuilder/ViewModel/ProductGrid.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+use Magento\Catalog\Helper\Product\Compare as CompareHelper;
+use Magento\Wishlist\Helper\Data as WishlistHelper;
+use Magento\Catalog\Model\Product;
+
+class ProductGrid implements ArgumentInterface
+{
+    public function __construct(
+        private CoreHelper $coreHelper,
+        private CompareHelper $compareHelper,
+        private WishlistHelper $wishlistHelper
+    ) {
+    }
+
+    public function filter(string $text): string
+    {
+        return $this->coreHelper->filter($text);
+    }
+
+    public function filterCarouselLazyImage(string $html): string
+    {
+        return $this->coreHelper->filterCarouselLazyImage($html);
+    }
+
+    public function isWishlistAllowed(): bool
+    {
+        return $this->wishlistHelper->isAllow();
+    }
+
+    public function getComparePostDataParams(Product $product): string
+    {
+        return $this->compareHelper->getPostDataParams($product);
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/templates/element/product_grid.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/product_grid.phtml
@@ -1,17 +1,18 @@
 <?php
+/** @var \Magezon\PageBuilder\Block\Element\ProductGrid $block */
+/** @var \Magezon\PageBuilder\ViewModel\ProductGrid $viewModel */
 use Magento\Framework\App\Action\Action;
 
-$coreHelper           = $this->helper('\Magezon\Core\Helper\Data');
-$compareHelper        = $this->helper('Magento\Catalog\Helper\Product\Compare');
-$element              = $this->getElement();
-$title                = $coreHelper->filter($element->getData('title'));
-$titleColor           = $element->getData('title_color');
-$titleAlign           = $element->getData('title_align');
-$titleTag             = $element->getData('title_tag') ? $element->getData('title_tag') : 'h2';
-$description          = $coreHelper->filter($element->getData('description'));
+$viewModel           = $block->getViewModel();
+$element             = $block->getElement();
+$title               = $viewModel->filter($element->getData('title'));
+$titleColor          = $element->getData('title_color');
+$titleAlign          = $element->getData('title_align');
+$titleTag            = $element->getData('title_tag') ? $element->getData('title_tag') : 'h2';
+$description         = $viewModel->filter($element->getData('description'));
 $showLine             = $element->getData('show_line');
 $linePosition         = $element->getData('line_position');
-$items                = $this->getItems();
+$items                = $block->getItems();
 $imageId              = 'category_page_grid';
 $templateType         = \Magento\Catalog\Block\Product\ReviewRendererInterface::SHORT_VIEW;
 $showImage            = $element->getData('product_image');
@@ -24,7 +25,7 @@ $showCart             = $element->getData('product_addtocart');
 $showReview           = $element->getData('product_review');
 $swatches             = $element->getData('product_swatches');
 $displayStyle         = $element->getData('display_style');
-$options = $this->getOwlCarouselOptions();
+$options = $block->getOwlCarouselOptions();
 $options['item_xl']   = $options['item_lg'] = $options['item_md'] = $options['item_sm'] = $options['item_xs'] = 1;
 $options['dots']      = $element->getData('owl_dots') ? true : false;
 $options['lazyLoad']  = true;
@@ -61,7 +62,9 @@ $htmlId               = $element->getHtmlId();
 		                    <a href="<?= $_product->getProductUrl() ?>" class="product photo product-item-photo" tabindex="-1">
 		                    	<?php
 		                    	$imgHtml = $productImage->toHtml();
-		                    	if ($displayStyle == 'pagination' && $lazyLoad) $imgHtml = $coreHelper->filterCarouselLazyImage($imgHtml);
+                                        if ($displayStyle == 'pagination' && $lazyLoad) {
+                                            $imgHtml = $viewModel->filterCarouselLazyImage($imgHtml);
+                                        }
 		                    	?>
 		                        <?= $imgHtml ?>
 		                    </a>
@@ -79,12 +82,12 @@ $htmlId               = $element->getHtmlId();
 
 								<?= $showPrice ? $block->getProductPrice($_product) : '' ?>
 
-								<?= $swatches ? $this->getSwatchesHtml($_product) : '' ?>
+                                                                <?= $swatches ? $block->getSwatchesHtml($_product) : '' ?>
 
 								<?= ($templateType && $showReview) ? $block->getReviewsSummaryHtml($_product, $templateType) : '' ?>
 
 								<?php if ($showShortDescription) { ?>
-									<div class="product-item-shortdescription"><?= $coreHelper->filter($_product->getShortDescription()) ?></div>
+                                                                        <div class="product-item-shortdescription"><?= $viewModel->filter($_product->getShortDescription()) ?></div>
 								<?php } ?>
 
 								<?php if ($showWishlist || $showCompare || $showCart) { ?>
@@ -118,7 +121,7 @@ $htmlId               = $element->getHtmlId();
 										<?php } ?>
 										<?php if ($showWishlist || $showCompare) { ?>
 											<div class="actions-secondary" data-role="add-to-links">
-												<?php if ($this->helper('Magento\Wishlist\Helper\Data')->isAllow() && $showWishlist) { ?>
+                                                                               <?php if ($viewModel->isWishlistAllowed() && $showWishlist) { ?>
 													<a href="#"
 														data-post='<?= $block->getAddToWishlistParams($_product) ?>'
 														class="action towishlist" data-action="add-to-wishlist"
@@ -128,7 +131,7 @@ $htmlId               = $element->getHtmlId();
 												<?php } ?>
 												<?php if ($block->getAddToCompareUrl() && $showCompare) { ?>
 													<a href="#" class="action tocompare"
-														data-post='<?= $compareHelper->getPostDataParams($_product) ?>'
+                                                                               data-post='<?= $viewModel->getComparePostDataParams($_product) ?>'
 														title="<?= __('Add to Compare') ?>">
 														<span><?= __('Add to Compare') ?></span>
 													</a>
@@ -154,3 +157,4 @@ $htmlId               = $element->getHtmlId();
 	}
 	</script>
 </div>
+


### PR DESCRIPTION
## Summary
- add `ProductGrid` ViewModel to encapsulate helper methods
- inject and expose ViewModel in `ProductGrid` block
- update template to use ViewModel and `$block` references

## Testing
- `php -l Magezon/PageBuilder/ViewModel/ProductGrid.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a56eda7c83208ec989a5f2a8d6fb