### PR TITLE
Switch product slider template to ViewModel

### DIFF
--- a/Magezon/PageBuilder/Block/Element/ProductSlider.php
+++ b/Magezon/PageBuilder/Block/Element/ProductSlider.php
@@ -19,6 +19,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\View\DesignInterface;
 use Magezon\Core\Model\ProductListFactory;
 use Magezon\Core\Helper\Data as CoreHelper;
+use Magezon\PageBuilder\ViewModel\ProductSlider as ViewModel;
 
 /**
  * Product slider block for page builder.
@@ -56,6 +57,11 @@ class ProductSlider extends \Magezon\Builder\Block\ListProduct
     private $design;
 
     /**
+     * @var ViewModel
+     */
+    private ViewModel $viewModel;
+
+    /**
      * Constructor.
      *
      * @param HttpContext $httpContext
@@ -73,6 +79,7 @@ class ProductSlider extends \Magezon\Builder\Block\ListProduct
         DesignInterface $design,
         ProductListFactory $productListFactory,
         CoreHelper $coreHelper,
+        ViewModel $viewModel,
         array $data = []
     ) {
         parent::__construct($data);
@@ -82,6 +89,12 @@ class ProductSlider extends \Magezon\Builder\Block\ListProduct
         $this->design = $design;
         $this->productListFactory = $productListFactory;
         $this->coreHelper = $coreHelper;
+        $this->viewModel = $viewModel;
+    }
+
+    public function getViewModel(): ViewModel
+    {
+        return $this->viewModel;
     }
 
     /**

--- a/Magezon/PageBuilder/ViewModel/ProductSlider.php
+++ b/Magezon/PageBuilder/ViewModel/ProductSlider.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+use Magento\Wishlist\Helper\Data as WishlistHelper;
+
+class ProductSlider implements ArgumentInterface
+{
+    public function __construct(
+        private CoreHelper $coreHelper,
+        private WishlistHelper $wishlistHelper
+    ) {}
+
+    public function filter(string $text): string
+    {
+        return $this->coreHelper->filter($text);
+    }
+
+    public function filterCarouselLazyImage(string $html): string
+    {
+        return $this->coreHelper->filterCarouselLazyImage($html);
+    }
+
+    public function serialize(array $data): string
+    {
+        return $this->coreHelper->serialize($data);
+    }
+
+    public function isWishlistAllowed(): bool
+    {
+        return $this->wishlistHelper->isAllow();
+    }
+}

--- a/Magezon/PageBuilder/view/frontend/templates/element/product_slider.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/product_slider.phtml
@@ -1,18 +1,20 @@
 <?php
+/** @var \Magezon\PageBuilder\Block\Element\ProductSlider $block */
+/** @var \Magezon\PageBuilder\ViewModel\ProductSlider $viewModel */
 use Magento\Framework\App\Action\Action;
 
-$coreHelper           = $this->helper('\Magezon\Core\Helper\Data');
-$compareHelper        = $this->helper('Magento\Catalog\Helper\Product\Compare');
-$element              = $this->getElement();
-$title                = $coreHelper->filter($element->getData('title'));
+$viewModel = $block->getViewModel();
+$compareHelper = $block->helper('Magento\Catalog\Helper\Product\Compare');
+$element       = $block->getElement();
+$title         = $viewModel->filter($element->getData('title'));
 $titleAlign           = $element->getData('title_align');
 $titleTag             = $element->getData('title_tag') ? $element->getData('title_tag') : 'h2';
-$description          = $coreHelper->filter($element->getData('description'));
+$description          = $viewModel->filter($element->getData('description'));
 $showLine             = $element->getData('show_line');
 $linePosition         = $element->getData('line_position');
-$carouselOptions      = $this->getOwlCarouselOptions();
+$carouselOptions      = $block->getOwlCarouselOptions();
 $lazyLoad             = $element->getData('owl_lazyload');
-$items                = $this->getItems();
+$items                = $block->getItems();
 $imageId              = 'category_page_grid';
 $templateType         = \Magento\Catalog\Block\Product\ReviewRendererInterface::SHORT_VIEW;
 $showImage            = $element->getData('product_image');
@@ -26,7 +28,7 @@ $showReview           = $element->getData('product_review');
 $swatches             = $element->getData('product_swatches');
 $htmlId               = $element->getHtmlId();
 $id                   = time() . uniqid();
-$classes              = $this->getOwlCarouselClasses();
+$classes              = $block->getOwlCarouselClasses();
 ?>
 <div class="mgz-block">
 	<?php if ($title || $description) { ?>
@@ -51,7 +53,7 @@ $classes              = $this->getOwlCarouselClasses();
 		                    <a href="<?= $_product->getProductUrl() ?>" class="product photo product-item-photo" tabindex="-1">
 		                    	<?php
 		                    	$imgHtml = $productImage->toHtml();
-		                    	if ($lazyLoad) $imgHtml = $coreHelper->filterCarouselLazyImage($imgHtml);
+                                        if ($lazyLoad) $imgHtml = $viewModel->filterCarouselLazyImage($imgHtml);
 		                    	?>
 		                        <?= $imgHtml ?>
 		                    </a>
@@ -69,12 +71,12 @@ $classes              = $this->getOwlCarouselClasses();
 
 								<?= $showPrice ? $block->getProductPrice($_product) : '' ?>
 
-								<?= $swatches ? $this->getSwatchesHtml($_product) : '' ?>
+                                                                <?= $swatches ? $block->getSwatchesHtml($_product) : '' ?>
 
 								<?= ($templateType && $showReview) ? $block->getReviewsSummaryHtml($_product, $templateType) : '' ?>
 
 								<?php if ($showShortDescription) { ?>
-									<div class="product-item-shortdescription"><?= $coreHelper->filter($_product->getShortDescription()) ?></div>
+                                                                        <div class="product-item-shortdescription"><?= $viewModel->filter($_product->getShortDescription()) ?></div>
 								<?php } ?>
 
 								<?php if ($showWishlist || $showCompare || $showCart) { ?>
@@ -108,7 +110,7 @@ $classes              = $this->getOwlCarouselClasses();
 										<?php } ?>
 										<?php if ($showWishlist || $showCompare) { ?>
 											<div class="actions-secondary" data-role="add-to-links">
-												<?php if ($this->helper('Magento\Wishlist\Helper\Data')->isAllow() && $showWishlist) { ?>
+                                                                               <?php if ($viewModel->isWishlistAllowed() && $showWishlist) { ?>
 													<a href="#"
 														data-post='<?= $block->getAddToWishlistParams($_product) ?>'
 														class="action towishlist" data-action="add-to-wishlist"
@@ -135,7 +137,7 @@ $classes              = $this->getOwlCarouselClasses();
 			</div>
 			<script>
 				require(['jquery', 'Magezon_Builder/js/carousel'], function($) {
-					$('#<?= $id ?>').carousel(<?= $coreHelper->serialize($carouselOptions) ?>);
+                                        $('#<?= $id ?>').carousel(<?= $viewModel->serialize($carouselOptions) ?>);
 				})
 			</script>
 		<?php } ?>


### PR DESCRIPTION
## Summary
- add `ProductSlider` view model
- inject view model into `ProductSlider` block
- refactor `product_slider.phtml` to use `$block` and view model

## Testing
- `php -l Magezon/PageBuilder/ViewModel/ProductSlider.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a571518083208756976985c5d110