### PR TITLE
Replace `$this` with `$block` in progress bar template

### DIFF
--- a/Magezon/PageBuilder/view/frontend/templates/element/progress_bar.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/progress_bar.phtml
@@ -1,6 +1,6 @@
 <?php
-$element      = $this->getElement();
-$items        = $this->toObjectArray($element->getData('items'));
+$element      = $block->getElement();
+$items        = $block->toObjectArray($element->getData('items'));
 $speed        = ((float) $element->getData('speed')) * 1000;
 $delay        = (float) $element->getData('delay');
 $unit         = $element->getData('units');


### PR DESCRIPTION
## Summary
- use the `$block` variable in the progress bar template

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/progress_bar.phtml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5760d64832091d09733f830436e