### PR TITLE
Implement ViewModel for raw_js template

### DIFF
--- a/Magezon/PageBuilder/ViewModel/RawJs.php
+++ b/Magezon/PageBuilder/ViewModel/RawJs.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Magezon\PageBuilder\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magezon\Core\Helper\Data as CoreHelper;
+
+class RawJs implements ArgumentInterface
+{
+    public function __construct(private CoreHelper $coreHelper) {}
+
+    public function getFilteredContent(string $content): string
+    {
+        return $this->coreHelper->filter($content);
+    }
+}
+

--- a/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_raw_js.xml
+++ b/Magezon/PageBuilder/view/frontend/layout/magezon_pagebuilder_raw_js.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="magezon.pagebuilder.raw_js">
+            <arguments>
+                <argument name="view_model" xsi:type="object">Magezon\PageBuilder\ViewModel\RawJs</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>
+

--- a/Magezon/PageBuilder/view/frontend/templates/element/raw_js.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/raw_js.phtml
@@ -1,5 +1,10 @@
 <?php
-$element    = $this->getElement();
-$coreHelper = $this->helper('\Magezon\Core\Helper\Data');
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magezon\PageBuilder\ViewModel\RawJs $viewModel
+ */
+$viewModel = $block->getViewModel();
+$element = $block->getElement();
 ?>
-<?= $coreHelper->filter($element->getContent()) ?>
+<?= $viewModel->getFilteredContent($element->getContent()) ?>
+


### PR DESCRIPTION
## Summary
- use a ViewModel for Raw JS element
- hook the ViewModel via layout
- update raw_js template to rely on `$block`

## Testing
- `php -l Magezon/PageBuilder/ViewModel/RawJs.php` *(fails: php not installed)*
- `php -l Magezon/PageBuilder/view/frontend/templates/element/raw_js.phtml` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a578215c83208576e5ddee8b7f11