### PR TITLE
Fix twitter button template

### DIFF
--- a/Magezon/PageBuilder/view/frontend/templates/element/twitter_button.phtml
+++ b/Magezon/PageBuilder/view/frontend/templates/element/twitter_button.phtml
@@ -1,5 +1,5 @@
 <?php
-$element    = $this->getElement();
+$element    = $block->getElement();
 $type       = $element->getButtonType();
 $attributes = [];
 $href = $attrs = $text = '';
@@ -59,7 +59,7 @@ switch ($type) {
 		}
 		break;
 }
-$attrs = $this->parseAttributes($attributes);
+$attrs = $block->parseAttributes($attributes);
 ?>
 
 <?php if ($href) { ?>


### PR DESCRIPTION
## Summary
- use `$block` variable in twitter button template

## Testing
- `php -l Magezon/PageBuilder/view/frontend/templates/element/twitter_button.phtml` *(fails: command not found)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6840a582308c8320b9d100ee2a7ccd5b